### PR TITLE
feat: add custom UserCreationForm to require email field

### DIFF
--- a/project/views.py
+++ b/project/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth import (
     authenticate,
     update_session_auth_hash,
 )
-from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.contrib.postgres.aggregates import ArrayAgg
@@ -24,7 +23,7 @@ from django.views.generic import TemplateView, CreateView
 from django_htmx.http import HttpResponseClientRedirect
 from django_htmx.http import retarget
 
-from .forms import ChangeProfileForm, ChangePasswordForm
+from .forms import ChangeProfileForm, ChangePasswordForm, UserCreationForm
 from .forms import CommentForm, LikeForm
 from .forms import PostForm, AttachmentForm
 from .models import Comment, LikeType, Like


### PR DESCRIPTION
Introduce a custom UserCreationForm that mandates the email field and enforces its uniqueness. This change ensures that every new user account has an associated email, enhancing user management and contactability. Adjust imports in views to use the updated form.